### PR TITLE
Add ready script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM debian:stretch-slim
 ARG STELLAR_HORIZON_VERSION="0.13.0"
 ARG STELLAR_HORIZON_BUILD_DEPS="wget"
 
+ARG STELLAR_HORIZON_DEPS="curl jq"
+
 LABEL maintainer="hello@satoshipay.io"
 
 # install stellar horizon
@@ -11,6 +13,8 @@ RUN /install.sh
 
 # HTTP port
 EXPOSE 8000
+
+ADD ready.sh /
 
 ADD entry.sh /
 ENTRYPOINT ["/entry.sh"]

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -ue
 
 # install deps
 apt-get update
-apt-get install -y $STELLAR_HORIZON_BUILD_DEPS
+apt-get install -y $STELLAR_HORIZON_BUILD_DEPS $STELLAR_HORIZON_DEPS
 
 # install horizon
 wget https://github.com/stellar/go/releases/download/horizon-v${STELLAR_HORIZON_VERSION}/horizon-v${STELLAR_HORIZON_VERSION}-linux-amd64.tar.gz -O stellar-horizon.tar.gz

--- a/ready.sh
+++ b/ready.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eu pipefail
+
+MAX_LEDGER_LAG=10
+
+CORE_LEDGER=$(curl --silent --max-time 2 ${STELLAR_CORE_URL}/info | jq -r .info.ledger.num)
+HORIZON_LEDGER=$(curl --silent --max-time 2 http://localhost:8000 | jq -r .history_latest_ledger)
+
+if (( HORIZON_LEDGER < CORE_LEDGER - MAX_LEDGER_LAG )); then
+  >&2 echo "Horizon ledger ${HORIZON_LEDGER} lagging more than ${MAX_LEDGER_LAG} ledgers behind Core ledger ${CORE_LEDGER}"
+  exit 1
+fi


### PR DESCRIPTION
Add `ready.sh` that fails if the Core ledger and Horizon ledger differ by more than 10 ledgers. Useful for Kubernetes readiness probes.